### PR TITLE
Fix bridge compile issue.

### DIFF
--- a/bridge/scripts/code_generator/package.json
+++ b/bridge/scripts/code_generator/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/lodash": "^4.14.172",
-    "@types/node": "^16.9.2",
+    "@types/node": "16.9.2",
     "commander": "^8.1.0",
     "glob": "^7.1.7",
     "json5": "^2.2.1",


### PR DESCRIPTION
This patch freeze the `@types/node` version to 16.9.2 to avoid breaking changes due the newer version of this package.