### PR TITLE
Tweak Android build

### DIFF
--- a/.github/workflows/publish_to_dart_dev.yml
+++ b/.github/workflows/publish_to_dart_dev.yml
@@ -109,7 +109,7 @@ jobs:
         name: ios_binary
         path: bridge/build/ios/
   build_android_binary:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4.1.3
       with:
@@ -121,10 +121,6 @@ jobs:
       with:
         version: ${{ env.pnpmVersion }}
         run_install: true
-    - uses: nttld/setup-ndk@v1.2.0
-      id: setup-ndk
-      with:
-        ndk-version: r26d
     - uses: jwlawson/actions-setup-cmake@v2.0.2
       with:
         cmake-version: ${{ env.cmakeVersion }}


### PR DESCRIPTION
`setup-ndk` is no longer necessary as the default macos-latest runner image includes NDK. 

Runner Image Docs: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#:~:text=58-,ndk,-24.0.8215888
GH:A Test: https://github.com/MulverineX/mercury/actions/runs/8996286718/job/24712541953

Also if we ever end up needing to use `setup-ndk` again in the future, they fixed support for arm64. https://github.com/nttld/setup-ndk/pull/549